### PR TITLE
Audiorate fixes, version bump to 0.3.0

### DIFF
--- a/docs/AUDIORATE_DATA.md
+++ b/docs/AUDIORATE_DATA.md
@@ -1,0 +1,69 @@
+# Changes since v0.2 (audiorate_fixes branch)
+
+## High-rate data support
+
+### Problem
+At audio-rate sample rates (10 kHz+), USB CDC on macOS delivers data in ~52 ms bursts rather than one event per line. The original architecture emitted one `serial://sample` IPC event per parsed line, causing massive IPC overhead and chart stutter.
+
+### Batch IPC (`serial://sample-batch`)
+- Read loop now accumulates all samples from a single `read()` call into a `Vec<SampleEvent>` and emits one `serial://sample-batch` event instead of N `serial://sample` events.
+- Reduces IPC crossings from O(samples/sec) to O(read-calls/sec) — ~50× reduction at 10 kHz.
+- Frontend `useSerialBackend.ts` subscribes to `serial://sample-batch` and calls `store.addSamples(batch)`.
+
+### Monotonic timestamps
+- Each parsed line now receives `t = max(real_now, last_t + 1)` — strictly increasing even when multiple lines arrive in one burst.
+- Spreads burst data evenly over time so the chart doesn't compress all burst samples to a single x-pixel.
+
+### Console raw event throttle
+- `serial://raw` events capped at 100/sec via a token-bucket `RawThrottle`.
+- The console pane can't usefully display more than ~100 lines/sec anyway; throttling prevents IPC saturation at high rates.
+
+### Chart rendering optimisations
+Three-layer improvement to keep the chart smooth at 500 k samples in the ring buffer:
+
+1. **Binary-search entry point** (`RingStore.forEachSampleFrom`): skips O(N) samples older than the visible window before iterating; timestamps are monotonically increasing so binary search is valid.
+2. **Merged multi-series pass**: replaced 3 separate `forEachSampleFrom` calls (one per visible series) with a single pass that accumulates a `Path2D` per series, cutting the iteration cost by ~3×.
+3. **Bucket scan range**: pixel-bucketed min-max downsampling now scans only `[startMs, endMs+200]` (matching the visible window) rather than an extended lookback.
+
+## Correctness fixes
+
+### Disconnect race
+Two races fixed that caused stale data to appear after disconnect:
+
+- **Mock stream**: `serial://status { connected }` and the `ActiveConnection` entry are now set *before* the worker thread is spawned, matching the fix already applied to `connect()`.
+- **Batch emit after stop**: read loop now checks `stop_flag` (SeqCst ordering) before emitting a batch; any in-flight samples are discarded rather than delivered after the status event.
+
+### Auto-pause on disconnect
+- `App.tsx` now auto-pauses the chart on `disconnected`/`error` status and auto-resumes on `connected`.
+- Prevents the live view from advancing wall-clock time while disconnected, which previously made old data appear to scroll as if live for minutes after disconnect.
+
+### Blank chart after tab switch
+- When the chart is paused and mounted fresh (e.g. switching console → chart tab), `viewRef.endMs` was 0 and `drawFrame` never initialised the viewport.
+- Fixed with an `else if (view.endMs === 0)` branch that seeds `endMs = Date.now()` on first paint.
+
+## Mock stream improvements
+
+### Available in production builds
+- Removed all `#[cfg(debug_assertions)]` guards from `start_mock_stream` command registration, Tauri menu item creation, and menu builder.
+- Mock controls in `Header.tsx` no longer gated behind `import.meta.env.DEV`.
+- The Mock submenu and `▶ Mock` button are now available in release builds.
+
+### Noise waveform fix
+- Old formula: `((t * 1234.567).sin() * 999.0).fract()` — output range `[0, 1)`, not centred, amplitude shrank to near-zero at high `t` values (10 kHz rate).
+- New formula: `(t * 7.31).sin() * 0.7 + (t * 3.17).cos() * 0.3` — range `[−1, 1]`, rate-independent, incommensurate frequencies give aperiodic appearance.
+
+## Code structure
+
+### Parser extracted to `parser.rs`
+- `LineResult` enum and `parse_line()` function moved from `lib.rs` to `src-tauri/src/parser.rs`.
+- `lib.rs` re-exports via `mod parser; use parser::{parse_line, LineResult};`.
+- `tests.rs` unchanged — `use super::*` picks up the re-export.
+
+### Native OS menu
+- Added OS-native menu bar with keyboard shortcuts (Cmd/Ctrl+1/2 for tabs, Cmd+R for connect/disconnect, Space for pause, Escape for back-to-live, Cmd+L to clear console).
+- macOS: App + Edit submenus; Windows/Linux: File + Edit submenus.
+- Menu actions emit `menu://action` Tauri events; `App.tsx` handler mirrors the keyboard shortcut logic.
+
+### First partial-line discard
+- Read loop now discards the first line fragment after connecting (the tail of a line already in flight when the port opened).
+- Prevents a garbage partial value from corrupting Y-axis auto-scale on connect.

--- a/examples/test_three_channels/test_three_channels.ino
+++ b/examples/test_three_channels/test_three_channels.ino
@@ -1,21 +1,21 @@
 /**
  * test_three_channels.ino
  *
- * Outputs three labelled channels at 100 Hz in SerialPlotster format:
+ * Outputs three labelled channels at RATE_HZ in SerialPlotster format:
  *   sin:0.9511,cos:0.3090,noise:0.1234
  *
  * The noise signal is a deterministic pseudo-noise (two mixed sinusoids)
  * that matches the SerialPlotster built-in mock stream.
  *
- * Compatible with any Arduino board at 115200 baud.
+ * Uses micros() so rates above 1000 Hz work correctly.
+ * Note: rates above ~2000 Hz require USB CDC (RP2040, Leonardo, etc.) —
+ * a hardware UART at 115200 baud tops out around 250 lines/sec.
  */
 
-static const int    RATE_HZ     = 100;
-static const float  DT          = 1.0f / RATE_HZ;
-static const unsigned long INTERVAL_MS = 1000UL / RATE_HZ;
+static const int           RATE_HZ     = 10000;
+static const unsigned long INTERVAL_US = 1000000UL / RATE_HZ;
 
-static float          t      = 0.0f;
-static unsigned long  lastMs = 0;
+static unsigned long lastUs = 0;
 
 void setup() {
   Serial.begin(115200);
@@ -23,17 +23,20 @@ void setup() {
 }
 
 void loop() {
-  unsigned long now = millis();
-  if (now - lastMs < INTERVAL_MS) return;
-  lastMs += INTERVAL_MS;   // drift-free: advance by fixed step, not now
+  unsigned long now = micros();
+  if (now - lastUs < INTERVAL_US) return;
+  lastUs += INTERVAL_US;   // drift-free: advance by fixed step, not now
 
+  // t = actual elapsed seconds so waveform frequency stays correct even when
+  // the serial link is slower than RATE_HZ (e.g. USB CDC throughput limit).
+  float t     = now * 1e-6f;
   float s     = sinf(t);
   float c     = cosf(t);
   float noise = (sinf(t * 7.31f) * 0.7f + cosf(t * 3.17f) * 0.3f) * 0.5f;
 
-  Serial.print("sin:");   Serial.print(s,     4);
-  Serial.print(",cos:");  Serial.print(c,     4);
-  Serial.print(",noise:"); Serial.println(noise, 4);
-
-  t += DT;
+  // Single write per line is much more efficient than multiple Serial.print()
+  // calls (avoids repeated USB packet flushes at high data rates).
+  char buf[48];
+  int  n = snprintf(buf, sizeof(buf), "sin:%.4f,cos:%.4f,noise:%.4f\r\n", s, c, noise);
+  Serial.write(buf, n);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serial-plotster",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "serial-plotster"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serial-plotster"
-version = "0.2.0"
+version = "0.3.0"
 description = "A cross-platform serial plotter for Arduino and other devices"
 authors = ["Tod Kurt <tod@todbot.com>"]
 license = "GPL-3.0-only"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,8 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::menu::{AboutMetadata, CheckMenuItem, MenuBuilder, MenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, State};
-#[cfg(debug_assertions)]
-use tauri::Manager;
+#[cfg(debug_assertions)] use tauri::Manager;
 
 // ── event payloads ────────────────────────────────────────────────────────────
 
@@ -404,9 +403,8 @@ fn connection_status(state: State<'_, AppState>) -> String {
     state.0.lock().unwrap().status.clone()
 }
 
-// ── mock stream (debug builds only) ──────────────────────────────────────────
+// ── mock stream ───────────────────────────────────────────────────────────────
 
-#[cfg(debug_assertions)]
 #[tauri::command]
 fn start_mock_stream(
     rate_hz: f64,
@@ -451,7 +449,7 @@ fn start_mock_stream(
                     (vec![tri], vec!["tri"])
                 }
                 "noise" => {
-                    let n = ((t * 1234.567).sin() * 999.0).fract();
+                    let n = (t * 7.31).sin() * 0.7 + (t * 3.17).cos() * 0.3;
                     (vec![n], vec!["noise"])
                 }
                 "sincos" => (vec![t.sin(), t.cos()], vec!["sin", "cos"]),
@@ -533,22 +531,21 @@ pub fn run() {
             let live_item    = MenuItem::with_id(app, "back-to-live",   "Back to Live",        true, Some("Escape"))?;
             let clear_item   = MenuItem::with_id(app, "clear-console",  "Clear Console",       true, Some("CmdOrCtrl+L"))?;
 
-            #[cfg(debug_assertions)]
             let mock_toggle_item = CheckMenuItem::with_id(
                 app, "toggle-mock", "Mock Controls", true, false, None::<&str>,
             )?;
 
-            let view_builder = SubmenuBuilder::new(app, "View")
+            let view_menu = SubmenuBuilder::new(app, "View")
                 .item(&chart_item)
                 .item(&console_item)
                 .separator()
                 .item(&pause_item)
                 .item(&live_item)
                 .separator()
-                .item(&clear_item);
-            #[cfg(debug_assertions)]
-            let view_builder = view_builder.separator().item(&mock_toggle_item);
-            let view_menu = view_builder.build()?;
+                .item(&clear_item)
+                .separator()
+                .item(&mock_toggle_item)
+                .build()?;
 
             // macOS: first submenu becomes the app menu (shown as the app name).
             // Hide/HideOthers/ShowAll are macOS-only conventions.
@@ -612,7 +609,6 @@ pub fn run() {
             disconnect,
             send_line,
             connection_status,
-            #[cfg(debug_assertions)]
             start_mock_stream,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::Write as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tauri::menu::{AboutMetadata, MenuBuilder, MenuItem, SubmenuBuilder};
+use tauri::menu::{AboutMetadata, CheckMenuItem, MenuBuilder, MenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, State};
 #[cfg(debug_assertions)]
 use tauri::Manager;
@@ -16,6 +16,11 @@ struct SampleEvent {
     t_ms: u64,
     values: Vec<f64>,
     labels: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Clone)]
+struct SampleBatch {
+    samples: Vec<SampleEvent>,
 }
 
 #[derive(Serialize, Clone)]
@@ -66,125 +71,58 @@ fn now_ms() -> u64 {
 
 // ── parser ────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, PartialEq)]
-enum LineResult {
-    /// A `# label1 label2 …` header line.
-    Header(Vec<String>),
-    /// A line of numeric data, optionally with inline `label:value` labels.
-    Data {
-        values: Vec<f64>,
-        /// `Some` when every token carried a `label:` prefix; `None` for bare values.
-        labels: Option<Vec<String>>,
-    },
-}
-
-/// Parse one trimmed, newline-stripped line.
-///
-/// Delimiter precedence: `,` → `\t` → ` ` (first delimiter yielding ≥1 valid token wins).
-/// Tokens may be bare floats or `label:float` pairs.
-/// Any token that cannot be interpreted as `f64` discards the entire line.
-fn parse_line(line: &str) -> Option<LineResult> {
-    let line = line.trim();
-    if line.is_empty() {
-        return None;
-    }
-
-    // Header line
-    if let Some(rest) = line.strip_prefix('#') {
-        let labels: Vec<String> = rest.split_whitespace().map(str::to_owned).collect();
-        return if labels.is_empty() { None } else { Some(LineResult::Header(labels)) };
-    }
-
-    // Strip optional Python tuple/list brackets: "(1,2,3)" or "[1,2,3]"
-    let line = match (line.chars().next(), line.chars().last()) {
-        (Some('('), Some(')')) | (Some('['), Some(']')) => line[1..line.len() - 1].trim(),
-        _ => line,
-    };
-    if line.is_empty() {
-        return None;
-    }
-
-    // Normalise "label: value" → "label:value" so spaced colons work with any delimiter.
-    let normalized;
-    let line = if line.contains(": ") {
-        normalized = line.replace(": ", ":");
-        normalized.as_str()
-    } else {
-        line
-    };
-
-    // Data line — try delimiters in precedence order
-    for &delim in &[',', '\t', ' '] {
-        let tokens: Vec<&str> = line
-            .split(delim)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect();
-        if tokens.is_empty() {
-            continue;
-        }
-
-        let mut values: Vec<f64> = Vec::with_capacity(tokens.len());
-        let mut labels: Vec<String> = Vec::with_capacity(tokens.len());
-        let mut has_labels = false;
-        let mut all_valid = true;
-
-        for token in &tokens {
-            if let Some(colon) = token.find(':') {
-                let label = &token[..colon];
-                let val_str = &token[colon + 1..];
-                match val_str.parse::<f64>() {
-                    Ok(v) => {
-                        values.push(v);
-                        labels.push(label.to_owned());
-                        has_labels = true;
-                    }
-                    Err(_) => {
-                        all_valid = false;
-                        break;
-                    }
-                }
-            } else {
-                match token.parse::<f64>() {
-                    Ok(v) => {
-                        values.push(v);
-                        labels.push(String::new());
-                    }
-                    Err(_) => {
-                        all_valid = false;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if all_valid && !values.is_empty() {
-            return Some(LineResult::Data {
-                values,
-                labels: if has_labels { Some(labels) } else { None },
-            });
-        }
-    }
-
-    None
-}
+mod parser;
+use parser::{parse_line, LineResult};
 
 // ── read loop ─────────────────────────────────────────────────────────────────
 
-/// Emit `serial://raw` and, on successful parse, `serial://sample`.
+/// Token-bucket throttle for raw console events.
+/// Refills at `rate_per_sec` tokens/second; one token consumed per allowed event.
+struct RawThrottle {
+    tokens: f64,
+    last_ms: u64,
+    rate_per_sec: f64,
+}
+
+impl RawThrottle {
+    fn new(rate_per_sec: f64) -> Self {
+        Self { tokens: rate_per_sec, last_ms: 0, rate_per_sec }
+    }
+
+    fn allow(&mut self, now_ms: u64) -> bool {
+        if now_ms > self.last_ms {
+            let elapsed = (now_ms - self.last_ms) as f64 / 1000.0;
+            self.tokens = (self.tokens + elapsed * self.rate_per_sec).min(self.rate_per_sec);
+            self.last_ms = now_ms;
+        }
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Parse one line, optionally emit `serial://raw`, and return a `SampleEvent`
+/// if the line contains numeric data.  Emits `serial://gap` immediately on a
+/// mid-stream header (can't be deferred to a batch).
 ///
-/// `t_ms` is supplied by the caller so that multiple lines from the same
-/// `read()` batch each get a distinct, monotonically-increasing timestamp
-/// rather than all sharing the same `now_ms()` value.
-fn process_line(line: &str, t_ms: u64, current_labels: &mut Vec<String>, app: &AppHandle) {
-    let _ = app.emit(
-        "serial://raw",
-        RawEvent {
-            t_ms,
-            direction: "rx".to_string(),
-            text: line.to_owned(),
-        },
-    );
+/// `t_ms` is supplied by the caller for monotonic per-line timestamps.
+/// `emit_raw` is false when the raw token bucket is exhausted.
+fn process_line(
+    line: &str,
+    t_ms: u64,
+    current_labels: &mut Vec<String>,
+    app: &AppHandle,
+    emit_raw: bool,
+) -> Option<SampleEvent> {
+    if emit_raw {
+        let _ = app.emit(
+            "serial://raw",
+            RawEvent { t_ms, direction: "rx".to_string(), text: line.to_owned() },
+        );
+    }
 
     match parse_line(line) {
         Some(LineResult::Header(labels)) => {
@@ -195,25 +133,15 @@ fn process_line(line: &str, t_ms: u64, current_labels: &mut Vec<String>, app: &A
                 let _ = app.emit("serial://gap", ());
             }
             *current_labels = labels;
+            None
         }
         Some(LineResult::Data { values, labels: inline }) => {
             let event_labels = inline.or_else(|| {
-                if current_labels.is_empty() {
-                    None
-                } else {
-                    Some(current_labels.clone())
-                }
+                if current_labels.is_empty() { None } else { Some(current_labels.clone()) }
             });
-            let _ = app.emit(
-                "serial://sample",
-                SampleEvent {
-                    t_ms,
-                    values,
-                    labels: event_labels,
-                },
-            );
+            Some(SampleEvent { t_ms, values, labels: event_labels })
         }
-        None => {}
+        None => None,
     }
 }
 
@@ -231,14 +159,25 @@ fn spawn_read_loop(
         let mut buf = [0u8; 4096];
         let mut line_buf = String::new();
         let mut current_labels: Vec<String> = Vec::new();
+        // Discard the first partial line so we only ever process complete lines.
+        // Connecting mid-transmission produces a tail fragment (e.g. "234\n") that
+        // parses as a garbage value and throws off Y-axis auto-scale.
+        let mut skip_first_line = true;
         // Monotonic timestamp: each parsed line gets at least 1 ms more than the
         // previous one so that lines arriving in the same OS read() batch (e.g.
         // several USB-buffered samples) are spread out on the time axis rather
         // than all collapsing to a single point.
         let mut last_t_ms: u64 = 0;
+        // Batch buffer: collect all samples from one read() call, then emit as a
+        // single serial://sample-batch event.  Reduces IPC crossings from
+        // O(samples/sec) to O(read-calls/sec), which matters at high data rates.
+        let mut batch: Vec<SampleEvent> = Vec::new();
+        // Raw event throttle: at high data rates the console can't display every
+        // line anyway, so cap raw events at 100/sec to avoid flooding IPC.
+        let mut raw_throttle = RawThrottle::new(100.0);
 
         loop {
-            if stop_flag.load(Ordering::Relaxed) {
+            if stop_flag.load(Ordering::SeqCst) {
                 break;
             }
 
@@ -259,17 +198,40 @@ fn spawn_read_loop(
                     let chunk = String::from_utf8_lossy(&buf[..n]);
                     for ch in chunk.chars() {
                         if ch == '\n' {
-                            let line = line_buf.trim_end_matches('\r').to_string();
-                            if !line.is_empty() {
-                                // Ensure each line gets a strictly increasing timestamp
-                                // even when multiple lines arrive in one read() call.
-                                let t = now_ms().max(last_t_ms + 1);
-                                last_t_ms = t;
-                                process_line(&line, t, &mut current_labels, &app);
+                            if skip_first_line {
+                                skip_first_line = false;
+                                line_buf.clear();
+                            } else {
+                                let line = line_buf.trim_end_matches('\r').to_string();
+                                if !line.is_empty() {
+                                    // Ensure each line gets a strictly increasing timestamp
+                                    // even when multiple lines arrive in one read() call.
+                                    let real_now = now_ms();
+                                    let t = real_now.max(last_t_ms + 1);
+                                    last_t_ms = t;
+                                    let emit_raw = raw_throttle.allow(real_now);
+                                    if let Some(s) = process_line(&line, t, &mut current_labels, &app, emit_raw) {
+                                        batch.push(s);
+                                    }
+                                }
+                                line_buf.clear();
                             }
-                            line_buf.clear();
                         } else if ch != '\r' {
                             line_buf.push(ch);
+                        }
+                    }
+                    // Emit all samples from this read() call as a single batch event.
+                    // Re-check stop_flag before emitting: if disconnect was called while
+                    // we were processing this buffer, drop the batch rather than racing
+                    // the status event to the frontend.
+                    if !batch.is_empty() {
+                        if stop_flag.load(Ordering::SeqCst) {
+                            batch.clear();
+                        } else {
+                            let _ = app.emit(
+                                "serial://sample-batch",
+                                SampleBatch { samples: std::mem::take(&mut batch) },
+                            );
                         }
                     }
                 }
@@ -302,7 +264,7 @@ fn stop_connection(state: &AppState) {
         inner.connection.take()
     };
     if let Some(conn) = old {
-        conn.stop_flag.store(true, Ordering::Relaxed);
+        conn.stop_flag.store(true, Ordering::SeqCst);
         drop(conn.write_port);
     }
 }
@@ -368,17 +330,8 @@ fn connect(
     let read_port = port.try_clone().map_err(|e| e.to_string())?;
     let stop_flag = Arc::new(AtomicBool::new(false));
 
-    spawn_read_loop(read_port, Arc::clone(&stop_flag), app.clone());
-
-    {
-        let mut inner = state.0.lock().unwrap();
-        inner.connection = Some(ActiveConnection {
-            write_port: Some(port),
-            stop_flag,
-        });
-        inner.status = "connected".to_string();
-    }
-
+    // Emit connected status and record state BEFORE spawning the read loop so
+    // the frontend's acceptingSamples gate is open before any sample events arrive.
     let _ = app.emit(
         "serial://status",
         StatusEvent {
@@ -386,6 +339,17 @@ fn connect(
             reason: None,
         },
     );
+
+    {
+        let mut inner = state.0.lock().unwrap();
+        inner.connection = Some(ActiveConnection {
+            write_port: Some(port),
+            stop_flag: Arc::clone(&stop_flag),
+        });
+        inner.status = "connected".to_string();
+    }
+
+    spawn_read_loop(read_port, stop_flag, app.clone());
 
     Ok(())
 }
@@ -456,6 +420,22 @@ fn start_mock_stream(
     let flag = Arc::clone(&stop_flag);
     let app_clone = app.clone();
 
+    {
+        let mut inner = state.0.lock().unwrap();
+        inner.connection = Some(ActiveConnection {
+            write_port: None,
+            stop_flag: Arc::clone(&stop_flag),
+        });
+        inner.status = "connected".to_string();
+    }
+    let _ = app.emit(
+        "serial://status",
+        StatusEvent {
+            state: "connected".to_string(),
+            reason: Some("mock stream".to_string()),
+        },
+    );
+
     std::thread::spawn(move || {
         let hz = rate_hz.max(0.001);
         let interval = Duration::from_secs_f64(1.0 / hz);
@@ -466,15 +446,20 @@ fn start_mock_stream(
             let (values, labels): (Vec<f64>, Vec<&str>) = match shape.as_str() {
                 "sin" => (vec![t.sin()], vec!["sin"]),
                 "cos" => (vec![t.cos()], vec!["cos"]),
+                "tri" => {
+                    let tri = 0.75 * (2.0 / std::f64::consts::PI) * (2.0 * t + std::f64::consts::FRAC_PI_2).sin().asin();
+                    (vec![tri], vec!["tri"])
+                }
                 "noise" => {
                     let n = ((t * 1234.567).sin() * 999.0).fract();
                     (vec![n], vec!["noise"])
                 }
                 "sincos" => (vec![t.sin(), t.cos()], vec!["sin", "cos"]),
                 _ => {
-                    // default "all": sin, cos, and a pseudo-noise signal
+                    // default "all": sin, cos, triangle, and a pseudo-noise signal
+                    let tri = 0.75 * (2.0 / std::f64::consts::PI) * (2.0 * t + std::f64::consts::FRAC_PI_2).sin().asin();
                     let noise = ((t * 7.31).sin() * 0.7 + (t * 3.17).cos() * 0.3) * 0.5;
-                    (vec![t.sin(), t.cos(), noise], vec!["sin", "cos", "noise"])
+                    (vec![t.sin(), t.cos(), tri, noise], vec!["sin", "cos", "tri", "noise"])
                 }
             };
 
@@ -500,23 +485,6 @@ fn start_mock_stream(
             std::thread::sleep(interval);
         }
     });
-
-    {
-        let mut inner = state.0.lock().unwrap();
-        inner.connection = Some(ActiveConnection {
-            write_port: None,
-            stop_flag,
-        });
-        inner.status = "connected".to_string();
-    }
-
-    let _ = app.emit(
-        "serial://status",
-        StatusEvent {
-            state: "connected".to_string(),
-            reason: Some("mock stream".to_string()),
-        },
-    );
 
     Ok(())
 }
@@ -565,15 +533,22 @@ pub fn run() {
             let live_item    = MenuItem::with_id(app, "back-to-live",   "Back to Live",        true, Some("Escape"))?;
             let clear_item   = MenuItem::with_id(app, "clear-console",  "Clear Console",       true, Some("CmdOrCtrl+L"))?;
 
-            let view_menu = SubmenuBuilder::new(app, "View")
+            #[cfg(debug_assertions)]
+            let mock_toggle_item = CheckMenuItem::with_id(
+                app, "toggle-mock", "Mock Controls", true, false, None::<&str>,
+            )?;
+
+            let view_builder = SubmenuBuilder::new(app, "View")
                 .item(&chart_item)
                 .item(&console_item)
                 .separator()
                 .item(&pause_item)
                 .item(&live_item)
                 .separator()
-                .item(&clear_item)
-                .build()?;
+                .item(&clear_item);
+            #[cfg(debug_assertions)]
+            let view_builder = view_builder.separator().item(&mock_toggle_item);
+            let view_menu = view_builder.build()?;
 
             // macOS: first submenu becomes the app menu (shown as the app name).
             // Hide/HideOthers/ShowAll are macOS-only conventions.
@@ -624,6 +599,7 @@ pub fn run() {
                     "toggle-pause"   => "toggle-pause",
                     "back-to-live"   => "back-to-live",
                     "clear-console"  => "clear-console",
+                    "toggle-mock"    => "toggle-mock",
                     _ => return,
                 };
                 let _ = app.emit("menu://action", action);
@@ -643,282 +619,5 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-// ── tests ─────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    // ── header lines ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn header_basic() {
-        assert_eq!(
-            parse_line("# temp hum pres"),
-            Some(LineResult::Header(vec![
-                "temp".into(),
-                "hum".into(),
-                "pres".into()
-            ]))
-        );
-    }
-
-    #[test]
-    fn header_single_label() {
-        assert_eq!(
-            parse_line("# voltage"),
-            Some(LineResult::Header(vec!["voltage".into()]))
-        );
-    }
-
-    #[test]
-    fn header_empty_is_none() {
-        assert_eq!(parse_line("#"), None);
-        assert_eq!(parse_line("#   "), None);
-    }
-
-    // ── bare numeric values ───────────────────────────────────────────────────
-
-    #[test]
-    fn bare_comma_delimited() {
-        assert_eq!(
-            parse_line("1.0,2.0,3.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn bare_tab_delimited() {
-        assert_eq!(
-            parse_line("1.0\t2.0\t3.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn bare_space_delimited() {
-        assert_eq!(
-            parse_line("1.0 2.0 3.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn single_value() {
-        assert_eq!(
-            parse_line("42.0"),
-            Some(LineResult::Data {
-                values: vec![42.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn negative_values() {
-        assert_eq!(
-            parse_line("-1.5,2.3,-0.0"),
-            Some(LineResult::Data {
-                values: vec![-1.5, 2.3, -0.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn scientific_notation() {
-        let r = parse_line("1e3,2.5e-1");
-        assert_eq!(
-            r,
-            Some(LineResult::Data {
-                values: vec![1000.0, 0.25],
-                labels: None,
-            })
-        );
-    }
-
-    // ── label:value pairs ─────────────────────────────────────────────────────
-
-    #[test]
-    fn label_value_comma() {
-        assert_eq!(
-            parse_line("temp:23.5,hum:45.2"),
-            Some(LineResult::Data {
-                values: vec![23.5, 45.2],
-                labels: Some(vec!["temp".into(), "hum".into()]),
-            })
-        );
-    }
-
-    #[test]
-    fn label_value_space() {
-        assert_eq!(
-            parse_line("x:1.0 y:2.0 z:3.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: Some(vec!["x".into(), "y".into(), "z".into()]),
-            })
-        );
-    }
-
-    #[test]
-    fn label_value_spaced_colon_space_delim() {
-        assert_eq!(
-            parse_line("temp: 23.5 hum: 45.2 co2: 339"),
-            Some(LineResult::Data {
-                values: vec![23.5, 45.2, 339.0],
-                labels: Some(vec!["temp".into(), "hum".into(), "co2".into()]),
-            })
-        );
-    }
-
-    #[test]
-    fn label_value_spaced_colon_comma_delim() {
-        assert_eq!(
-            parse_line("temp: 23.5,hum: 45.2,co2: 339"),
-            Some(LineResult::Data {
-                values: vec![23.5, 45.2, 339.0],
-                labels: Some(vec!["temp".into(), "hum".into(), "co2".into()]),
-            })
-        );
-    }
-
-    #[test]
-    fn label_value_single() {
-        assert_eq!(
-            parse_line("voltage:3.3"),
-            Some(LineResult::Data {
-                values: vec![3.3],
-                labels: Some(vec!["voltage".into()]),
-            })
-        );
-    }
-
-    // ── invalid / dropped lines ───────────────────────────────────────────────
-
-    #[test]
-    fn non_numeric_text_is_none() {
-        assert_eq!(parse_line("hello world"), None);
-    }
-
-    #[test]
-    fn mixed_invalid_token_drops_line() {
-        assert_eq!(parse_line("1.0,foo,3.0"), None);
-    }
-
-    #[test]
-    fn empty_line_is_none() {
-        assert_eq!(parse_line(""), None);
-        assert_eq!(parse_line("   "), None);
-    }
-
-    #[test]
-    fn bad_label_value_drops_line() {
-        assert_eq!(parse_line("temp:notanumber"), None);
-    }
-
-    // ── delimiter precedence ──────────────────────────────────────────────────
-
-    #[test]
-    fn comma_takes_precedence_over_space() {
-        // "1.0,2.0" — comma wins, not split by space
-        assert_eq!(
-            parse_line("1.0,2.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn tab_takes_precedence_over_space() {
-        // "1.0\t2.0" — tab wins over space
-        assert_eq!(
-            parse_line("1.0\t2.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0],
-                labels: None,
-            })
-        );
-    }
-
-    // ── whitespace tolerance ──────────────────────────────────────────────────
-
-    #[test]
-    fn leading_trailing_whitespace_trimmed() {
-        assert_eq!(
-            parse_line("  1.0,2.0  "),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn spaces_around_comma_tokens() {
-        assert_eq!(
-            parse_line("1.0 , 2.0 , 3.0"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    // ── Python tuple / list syntax ────────────────────────────────────────────
-
-    #[test]
-    fn python_tuple() {
-        assert_eq!(
-            parse_line("(1, 2, 3)"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn python_list() {
-        assert_eq!(
-            parse_line("[1.5, -2.5, 3.0]"),
-            Some(LineResult::Data {
-                values: vec![1.5, -2.5, 3.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn python_tuple_single() {
-        assert_eq!(
-            parse_line("(42.0)"),
-            Some(LineResult::Data {
-                values: vec![42.0],
-                labels: None,
-            })
-        );
-    }
-
-    #[test]
-    fn python_list_with_spaces() {
-        assert_eq!(
-            parse_line("[ 1.0 , 2.0 , 3.0 ]"),
-            Some(LineResult::Data {
-                values: vec![1.0, 2.0, 3.0],
-                labels: None,
-            })
-        );
-    }
-}
+mod tests;

--- a/src-tauri/src/parser.rs
+++ b/src-tauri/src/parser.rs
@@ -1,0 +1,102 @@
+#[derive(Debug, PartialEq)]
+pub(crate) enum LineResult {
+    /// A `# label1 label2 …` header line.
+    Header(Vec<String>),
+    /// A line of numeric data, optionally with inline `label:value` labels.
+    Data {
+        values: Vec<f64>,
+        /// `Some` when every token carried a `label:` prefix; `None` for bare values.
+        labels: Option<Vec<String>>,
+    },
+}
+
+/// Parse one trimmed, newline-stripped line.
+///
+/// Delimiter precedence: `,` → `\t` → ` ` (first delimiter yielding ≥1 valid token wins).
+/// Tokens may be bare floats or `label:float` pairs.
+/// Any token that cannot be interpreted as `f64` discards the entire line.
+pub(crate) fn parse_line(line: &str) -> Option<LineResult> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    // Header line
+    if let Some(rest) = line.strip_prefix('#') {
+        let labels: Vec<String> = rest.split_whitespace().map(str::to_owned).collect();
+        return if labels.is_empty() { None } else { Some(LineResult::Header(labels)) };
+    }
+
+    // Strip optional Python tuple/list brackets: "(1,2,3)" or "[1,2,3]"
+    let line = match (line.chars().next(), line.chars().last()) {
+        (Some('('), Some(')')) | (Some('['), Some(']')) => line[1..line.len() - 1].trim(),
+        _ => line,
+    };
+    if line.is_empty() {
+        return None;
+    }
+
+    // Normalise "label: value" → "label:value" so spaced colons work with any delimiter.
+    let normalized;
+    let line = if line.contains(": ") {
+        normalized = line.replace(": ", ":");
+        normalized.as_str()
+    } else {
+        line
+    };
+
+    // Data line — try delimiters in precedence order
+    for &delim in &[',', '\t', ' '] {
+        let tokens: Vec<&str> = line
+            .split(delim)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if tokens.is_empty() {
+            continue;
+        }
+
+        let mut values: Vec<f64> = Vec::with_capacity(tokens.len());
+        let mut labels: Vec<String> = Vec::with_capacity(tokens.len());
+        let mut has_labels = false;
+        let mut all_valid = true;
+
+        for token in &tokens {
+            if let Some(colon) = token.find(':') {
+                let label = &token[..colon];
+                let val_str = &token[colon + 1..];
+                match val_str.parse::<f64>() {
+                    Ok(v) => {
+                        values.push(v);
+                        labels.push(label.to_owned());
+                        has_labels = true;
+                    }
+                    Err(_) => {
+                        all_valid = false;
+                        break;
+                    }
+                }
+            } else {
+                match token.parse::<f64>() {
+                    Ok(v) => {
+                        values.push(v);
+                        labels.push(String::new());
+                    }
+                    Err(_) => {
+                        all_valid = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if all_valid && !values.is_empty() {
+            return Some(LineResult::Data {
+                values,
+                labels: if has_labels { Some(labels) } else { None },
+            });
+        }
+    }
+
+    None
+}

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1,0 +1,274 @@
+use super::*;
+
+// ── header lines ──────────────────────────────────────────────────────────
+
+#[test]
+fn header_basic() {
+    assert_eq!(
+        parse_line("# temp hum pres"),
+        Some(LineResult::Header(vec![
+            "temp".into(),
+            "hum".into(),
+            "pres".into()
+        ]))
+    );
+}
+
+#[test]
+fn header_single_label() {
+    assert_eq!(
+        parse_line("# voltage"),
+        Some(LineResult::Header(vec!["voltage".into()]))
+    );
+}
+
+#[test]
+fn header_empty_is_none() {
+    assert_eq!(parse_line("#"), None);
+    assert_eq!(parse_line("#   "), None);
+}
+
+// ── bare numeric values ───────────────────────────────────────────────────
+
+#[test]
+fn bare_comma_delimited() {
+    assert_eq!(
+        parse_line("1.0,2.0,3.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn bare_tab_delimited() {
+    assert_eq!(
+        parse_line("1.0\t2.0\t3.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn bare_space_delimited() {
+    assert_eq!(
+        parse_line("1.0 2.0 3.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn single_value() {
+    assert_eq!(
+        parse_line("42.0"),
+        Some(LineResult::Data {
+            values: vec![42.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn negative_values() {
+    assert_eq!(
+        parse_line("-1.5,2.3,-0.0"),
+        Some(LineResult::Data {
+            values: vec![-1.5, 2.3, -0.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn scientific_notation() {
+    let r = parse_line("1e3,2.5e-1");
+    assert_eq!(
+        r,
+        Some(LineResult::Data {
+            values: vec![1000.0, 0.25],
+            labels: None,
+        })
+    );
+}
+
+// ── label:value pairs ─────────────────────────────────────────────────────
+
+#[test]
+fn label_value_comma() {
+    assert_eq!(
+        parse_line("temp:23.5,hum:45.2"),
+        Some(LineResult::Data {
+            values: vec![23.5, 45.2],
+            labels: Some(vec!["temp".into(), "hum".into()]),
+        })
+    );
+}
+
+#[test]
+fn label_value_space() {
+    assert_eq!(
+        parse_line("x:1.0 y:2.0 z:3.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: Some(vec!["x".into(), "y".into(), "z".into()]),
+        })
+    );
+}
+
+#[test]
+fn label_value_spaced_colon_space_delim() {
+    assert_eq!(
+        parse_line("temp: 23.5 hum: 45.2 co2: 339"),
+        Some(LineResult::Data {
+            values: vec![23.5, 45.2, 339.0],
+            labels: Some(vec!["temp".into(), "hum".into(), "co2".into()]),
+        })
+    );
+}
+
+#[test]
+fn label_value_spaced_colon_comma_delim() {
+    assert_eq!(
+        parse_line("temp: 23.5,hum: 45.2,co2: 339"),
+        Some(LineResult::Data {
+            values: vec![23.5, 45.2, 339.0],
+            labels: Some(vec!["temp".into(), "hum".into(), "co2".into()]),
+        })
+    );
+}
+
+#[test]
+fn label_value_single() {
+    assert_eq!(
+        parse_line("voltage:3.3"),
+        Some(LineResult::Data {
+            values: vec![3.3],
+            labels: Some(vec!["voltage".into()]),
+        })
+    );
+}
+
+// ── invalid / dropped lines ───────────────────────────────────────────────
+
+#[test]
+fn non_numeric_text_is_none() {
+    assert_eq!(parse_line("hello world"), None);
+}
+
+#[test]
+fn mixed_invalid_token_drops_line() {
+    assert_eq!(parse_line("1.0,foo,3.0"), None);
+}
+
+#[test]
+fn empty_line_is_none() {
+    assert_eq!(parse_line(""), None);
+    assert_eq!(parse_line("   "), None);
+}
+
+#[test]
+fn bad_label_value_drops_line() {
+    assert_eq!(parse_line("temp:notanumber"), None);
+}
+
+// ── delimiter precedence ──────────────────────────────────────────────────
+
+#[test]
+fn comma_takes_precedence_over_space() {
+    // "1.0,2.0" — comma wins, not split by space
+    assert_eq!(
+        parse_line("1.0,2.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn tab_takes_precedence_over_space() {
+    // "1.0\t2.0" — tab wins over space
+    assert_eq!(
+        parse_line("1.0\t2.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0],
+            labels: None,
+        })
+    );
+}
+
+// ── whitespace tolerance ──────────────────────────────────────────────────
+
+#[test]
+fn leading_trailing_whitespace_trimmed() {
+    assert_eq!(
+        parse_line("  1.0,2.0  "),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn spaces_around_comma_tokens() {
+    assert_eq!(
+        parse_line("1.0 , 2.0 , 3.0"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}
+
+// ── Python tuple / list syntax ────────────────────────────────────────────
+
+#[test]
+fn python_tuple() {
+    assert_eq!(
+        parse_line("(1, 2, 3)"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn python_list() {
+    assert_eq!(
+        parse_line("[1.5, -2.5, 3.0]"),
+        Some(LineResult::Data {
+            values: vec![1.5, -2.5, 3.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn python_tuple_single() {
+    assert_eq!(
+        parse_line("(42.0)"),
+        Some(LineResult::Data {
+            values: vec![42.0],
+            labels: None,
+        })
+    );
+}
+
+#[test]
+fn python_list_with_spaces() {
+    assert_eq!(
+        parse_line("[ 1.0 , 2.0 , 3.0 ]"),
+        Some(LineResult::Data {
+            values: vec![1.0, 2.0, 3.0],
+            labels: None,
+        })
+    );
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SerialPlotster",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.todbot.serial-plotster",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ export default function App() {
 
   const [tab, setTab] = useState<'chart' | 'console'>('chart');
   const [paused, setPaused] = useState(false);
+  const [showMock, setShowMock] = useState(false);
   const [windowMs, setWindowMs] = useState(30_000);
   const [scrubbing, setScrubbing] = useState(false);
   const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
@@ -48,9 +49,14 @@ export default function App() {
   // Load ports on mount only. Use the ⟳ Ports button to refresh manually.
   useEffect(() => { listPorts(); }, [listPorts]);
 
-  // Exit scrub mode whenever a new connection is established.
+  // On connect: resume live view. On disconnect: pause so old data stops scrolling.
   useEffect(() => {
-    if (status === 'connected') resetView();
+    if (status === 'connected') {
+      setPaused(false);
+      resetView();
+    } else if (status === 'disconnected' || status === 'error') {
+      setPaused(true);
+    }
   }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Menu event handler — mirrors keyboard shortcuts.
@@ -64,6 +70,7 @@ export default function App() {
           else if (lastConnectRef.current) connect(lastConnectRef.current);
           break;
         case 'toggle-pause':  setPaused((p) => { if (p) resetView(); return !p; }); break;
+        case 'toggle-mock':   setShowMock((m) => !m); break;
         case 'back-to-live':  plotRef.current?.resetToLive(); setScrubbing(false); break;
         case 'clear-console': consoleStore.clear(); break;
       }
@@ -138,7 +145,7 @@ export default function App() {
         onRefreshPorts={listPorts}
         onConnect={(path, baud) => { lastConnectRef.current = { path, baud }; connect({ path, baud }); }}
         onDisconnect={disconnect}
-        onMock={(shape) => startMockStream(shape)}
+        onMock={showMock ? (shape, rate) => startMockStream(shape, rate) : undefined}
       />
 
       <TabNav active={tab} onChange={setTab} />

--- a/src/components/ConsoleLog.tsx
+++ b/src/components/ConsoleLog.tsx
@@ -8,22 +8,34 @@ interface ConsoleLogProps {
 
 export function ConsoleLog({ store }: ConsoleLogProps) {
   const [lines, setLines] = useState<readonly RawEvent[]>(store.lines);
-  const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const atBottomRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
+
+  function scrollToBottom() {
+    const el = containerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }
 
   useEffect(() => store.subscribe(() => setLines([...store.lines])), [store]);
 
+  useEffect(() => { scrollToBottom(); }, []); // scroll to bottom on mount
+
   useEffect(() => {
-    if (atBottomRef.current) {
-      bottomRef.current?.scrollIntoView();
-    }
+    if (atBottomRef.current) scrollToBottom();
   }, [lines]);
 
   function onScroll() {
     const el = containerRef.current;
     if (!el) return;
-    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 16;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 16;
+    if (atBottom) {
+      atBottomRef.current = true;
+    } else if (el.scrollTop < lastScrollTopRef.current) {
+      // Only disable auto-scroll when the user scrolls up, not on spurious events.
+      atBottomRef.current = false;
+    }
+    lastScrollTopRef.current = el.scrollTop;
   }
 
   return (
@@ -45,7 +57,6 @@ export function ConsoleLog({ store }: ConsoleLogProps) {
           </span>
         </div>
       ))}
-      <div ref={bottomRef} />
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,7 +77,7 @@ export function Header({ status, ports, onRefreshPorts, onConnect, onDisconnect,
         </button>
       )}
 
-      {import.meta.env.DEV && onMock && !connected && (
+      {onMock && !connected && (
         <>
           <div className="w-px h-5 bg-gray-600 mx-1" />
           <select

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,8 @@ import type { ConnectionState } from '../types/serial';
 
 const BAUD_RATES = [1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
 
-const MOCK_SHAPES = ['all', 'sincos', 'sin', 'cos', 'noise'];
+const MOCK_SHAPES = ['all', 'sincos', 'sin', 'cos', 'tri', 'noise'];
+const MOCK_RATES = [10, 100, 1000, 10000];
 
 interface HeaderProps {
   status: ConnectionState;
@@ -11,13 +12,14 @@ interface HeaderProps {
   onRefreshPorts: () => void;
   onConnect: (port: string, baud: number) => void;
   onDisconnect: () => void;
-  onMock?: (shape: string) => void;
+  onMock?: (shape: string, rate: number) => void;
 }
 
 export function Header({ status, ports, onRefreshPorts, onConnect, onDisconnect, onMock }: HeaderProps) {
   const [port, setPort] = useState('');
   const [baud, setBaud] = useState(115200);
   const [mockShape, setMockShape] = useState('all');
+  const [mockRate, setMockRate] = useState(100);
   const connected = status === 'connected';
 
   useEffect(() => {
@@ -85,8 +87,15 @@ export function Header({ status, ports, onRefreshPorts, onConnect, onDisconnect,
           >
             {MOCK_SHAPES.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
+          <select
+            value={mockRate}
+            onChange={(e) => setMockRate(Number(e.target.value))}
+            className="bg-gray-700 text-xs text-gray-300 rounded px-1.5 py-1 border border-gray-600 [&>option]:bg-gray-700 [&>option]:text-white [color-scheme:dark]"
+          >
+            {MOCK_RATES.map((r) => <option key={r} value={r}>{r} Hz</option>)}
+          </select>
           <button
-            onClick={() => onMock(mockShape)}
+            onClick={() => onMock(mockShape, mockRate)}
             className="text-xs bg-purple-700 hover:bg-purple-600 text-white rounded px-2 py-1"
           >
             ▶ Mock

--- a/src/components/PlotCanvas.tsx
+++ b/src/components/PlotCanvas.tsx
@@ -54,11 +54,6 @@ function drawFrame(
   props: DrawProps,
   lastAutoYRange: { min: number; max: number },
 ): void {
-  if (view.mode === 'live' && !props.paused) {
-    view.endMs = Date.now();
-    view.startMs = view.endMs - props.windowMs;
-  }
-
   const W = canvas.width / dpr;
   const H = canvas.height / dpr;
 
@@ -72,6 +67,20 @@ function drawFrame(
   const plotH = H - PAD.top - PAD.bottom;
   if (plotW <= 0 || plotH <= 0) return;
 
+  if (view.mode === 'live' && !props.paused) {
+    // Snap endMs to pixel-grid boundaries so every sample's pixel-column
+    // assignment is stable between scroll steps — prevents Y-jitter.
+    const now = Date.now();
+    const msPerPixel = props.windowMs / plotW;
+    view.endMs = Math.ceil(now / msPerPixel) * msPerPixel;
+    view.startMs = view.endMs - props.windowMs;
+  } else if (view.endMs === 0) {
+    // First render while paused (e.g. tab re-mount while disconnected):
+    // initialize to current time so the ring buffer data is visible.
+    view.endMs = Date.now();
+    view.startMs = view.endMs - props.windowMs;
+  }
+
   const { startMs, endMs } = view;
   const spanMs = endMs - startMs || 1;
 
@@ -79,38 +88,67 @@ function drawFrame(
   const yOf = (v: number, yMin: number, range: number) =>
     plotT + (1 - (v - yMin) / range) * plotH;
 
-  // ── Y range ────────────────────────────────────────────────────────────────
-  const scanStart = startMs - spanMs; // one extra window back for smooth entry at left edge
+  // ── pixel-bucketed min-max downsampling (Y-range only, visible window) ───────
+  // Scan only [startMs, endMs+200] — no need for the left-entry extension here
+  // because firstVisibleBucket == 0 when we start at startMs.
+  const numBuckets = Math.ceil(plotW);
+  const bucketSpan = endMs + 200 - startMs || 1;
+
+  type BucketData = { mins: Float32Array; maxs: Float32Array; raw: Float32Array };
+  const buckets = new Map<string, BucketData>();
+  for (const key of props.seriesKeys) {
+    if (!props.visible.has(key)) continue;
+    const raw = store.getSeriesData(key);
+    if (!raw) continue;
+    buckets.set(key, {
+      raw,
+      mins: new Float32Array(numBuckets).fill(Infinity),
+      maxs: new Float32Array(numBuckets).fill(-Infinity),
+    });
+  }
+
+  if (buckets.size > 0) {
+    store.forEachSampleFrom(startMs, (t, ri) => {
+      if (t > endMs + 200) return false;
+      const bi = Math.min(numBuckets - 1, Math.floor((t - startMs) / bucketSpan * numBuckets));
+      for (const bd of buckets.values()) {
+        const v = bd.raw[ri];
+        if (!isNaN(v)) {
+          if (v < bd.mins[bi]) bd.mins[bi] = v;
+          if (v > bd.maxs[bi]) bd.maxs[bi] = v;
+        }
+      }
+    });
+  }
+
+  // ── Y range (derived from buckets, or fixed) ───────────────────────────────
   let yMin: number, yMax: number;
   if (props.yRange) {
-    // Fixed mode — use caller-supplied bounds directly
     yMin = props.yRange.min;
     yMax = props.yRange.max;
     if (yMin === yMax) { yMin -= 1; yMax += 1; }
   } else {
-    // Auto mode — scan visible data in the current window
     yMin = Infinity; yMax = -Infinity;
-    for (const key of props.seriesKeys) {
-      if (!props.visible.has(key)) continue;
-      store.forEachSample((t, ri) => {
-        if (t < scanStart) return;
-        if (t > endMs) return false;
-        const v = store.getValue(key, ri);
-        if (!isNaN(v) && t >= startMs) {
-          if (v < yMin) yMin = v;
-          if (v > yMax) yMax = v;
+    for (const { mins, maxs } of buckets.values()) {
+      for (let i = 0; i < numBuckets; i++) {
+        if (mins[i] !== Infinity) {
+          if (mins[i] < yMin) yMin = mins[i];
+          if (maxs[i] > yMax) yMax = maxs[i];
         }
-      });
+      }
     }
     if (!isFinite(yMin)) { yMin = -1; yMax = 1; }
     if (yMin === yMax) { yMin -= 1; yMax += 1; }
     const yPad = (yMax - yMin) * 0.06;
     yMin -= yPad; yMax += yPad;
-    // Remember for getAutoYRange()
     lastAutoYRange.min = yMin;
     lastAutoYRange.max = yMax;
   }
   const yRange = yMax - yMin;
+
+  // Left-entry scan start for line drawing: enough context for a line to enter
+  // from off-screen left, but capped at 1 s so high-rate data stays fast.
+  const scanStart = startMs - Math.min(spanMs, 1000);
 
   // ── Y grid + labels ────────────────────────────────────────────────────────
   ctx.font = '10px monospace';
@@ -143,7 +181,9 @@ function drawFrame(
   ctx.lineWidth = 1;
   ctx.strokeRect(plotL, plotT, plotW, plotH);
 
-  // ── series lines (clipped) ─────────────────────────────────────────────────
+  // ── series lines (inline pixel-bucket downsampling) ───────────────────────
+  // Groups samples by pixel column using actual sample timestamps for x —
+  // preserves connectivity and exact positions at all zoom levels.
   ctx.save();
   ctx.beginPath();
   ctx.rect(plotL, plotT, plotW, plotH);
@@ -152,24 +192,65 @@ function drawFrame(
   ctx.lineWidth = 1.5;
   ctx.lineJoin = 'round';
 
+  // Collect only the active (visible) series to avoid per-sample Map lookups.
+  const activeSeries: { bd: BucketData; color: string }[] = [];
   for (let si = 0; si < props.seriesKeys.length; si++) {
-    const key = props.seriesKeys[si];
-    if (!props.visible.has(key)) continue;
-    ctx.strokeStyle = seriesColor(si);
-    ctx.beginPath();
-    let pen = false;
+    const bd = buckets.get(props.seriesKeys[si]);
+    if (bd) activeSeries.push({ bd, color: seriesColor(si) });
+  }
+  const nSeries = activeSeries.length;
 
-    store.forEachSample((t, ri) => {
-      if (t > endMs + 200) return false; // stop well past right edge
-      const v = store.getValue(key, ri);
-      if (isNaN(v)) { pen = false; return; }
-      if (t < scanStart) { pen = false; return; } // way too old, skip
-      const x = xOf(t);
-      const y = yOf(v, yMin, yRange);
-      if (pen) ctx.lineTo(x, y); else { ctx.moveTo(x, y); pen = true; }
+  if (nSeries > 0) {
+    // Per-series pixel-accumulator state — kept flat for cache locality.
+    const pens    = new Uint8Array(nSeries);          // 0 = no pen
+    const lastPxs = new Int32Array(nSeries).fill(Number.MIN_SAFE_INTEGER);
+    const pxMins  = new Float32Array(nSeries).fill(Infinity);
+    const pxMaxs  = new Float32Array(nSeries).fill(-Infinity);
+    const pxTs    = new Float64Array(nSeries);
+    // One path per series — pre-opened so the single scan can append to any of them.
+    const paths   = activeSeries.map(() => new Path2D());
+
+    store.forEachSampleFrom(scanStart, (t, ri) => {
+      if (t > endMs + 200) return false;
+      const px = Math.floor(xOf(t));
+      for (let si = 0; si < nSeries; si++) {
+        const v = activeSeries[si].bd.raw[ri];
+        if (isNaN(v)) {
+          // Flush accumulated pixel then break the line.
+          if (pxMins[si] !== Infinity) {
+            const x = xOf(pxTs[si]);
+            const y = yOf((pxMins[si] + pxMaxs[si]) * 0.5, yMin, yRange);
+            if (pens[si]) paths[si].lineTo(x, y); else { paths[si].moveTo(x, y); pens[si] = 1; }
+            pxMins[si] = Infinity; pxMaxs[si] = -Infinity;
+          }
+          pens[si] = 0; lastPxs[si] = Number.MIN_SAFE_INTEGER;
+          continue;
+        }
+        if (px !== lastPxs[si]) {
+          // Flush previous pixel.
+          if (pxMins[si] !== Infinity) {
+            const x = xOf(pxTs[si]);
+            const y = yOf((pxMins[si] + pxMaxs[si]) * 0.5, yMin, yRange);
+            if (pens[si]) paths[si].lineTo(x, y); else { paths[si].moveTo(x, y); pens[si] = 1; }
+          }
+          lastPxs[si] = px; pxMins[si] = v; pxMaxs[si] = v; pxTs[si] = t;
+        } else {
+          if (v < pxMins[si]) pxMins[si] = v;
+          if (v > pxMaxs[si]) pxMaxs[si] = v;
+        }
+      }
     });
 
-    ctx.stroke();
+    // Flush final pixel for each series and stroke.
+    for (let si = 0; si < nSeries; si++) {
+      if (pxMins[si] !== Infinity) {
+        const x = xOf(pxTs[si]);
+        const y = yOf((pxMins[si] + pxMaxs[si]) * 0.5, yMin, yRange);
+        if (pens[si]) paths[si].lineTo(x, y); else paths[si].moveTo(x, y);
+      }
+      ctx.strokeStyle = activeSeries[si].color;
+      ctx.stroke(paths[si]);
+    }
   }
 
   ctx.restore();

--- a/src/hooks/useRingBuffer.ts
+++ b/src/hooks/useRingBuffer.ts
@@ -1,8 +1,8 @@
 import { useCallback, useRef, useState } from 'react';
 import { RingStore } from '../store/RingStore';
 
-export function useRingBuffer(capacity = 100_000) {
-  const store = useRef(new RingStore(capacity)).current;
+export function useRingBuffer() {
+  const store = useRef(new RingStore()).current;
   const [seriesKeys, setSeriesKeys] = useState<string[]>([]);
 
   const onNewSeries = useCallback(() => {

--- a/src/hooks/useSerialBackend.ts
+++ b/src/hooks/useSerialBackend.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import type { SampleEvent, RawEvent, StatusEvent, ConnectionState } from '../types/serial';
+import type { SampleEvent, SampleBatch, RawEvent, StatusEvent, ConnectionState } from '../types/serial';
 import type { RingStore } from '../store/RingStore';
 import type { ConsoleStore } from '../store/ConsoleStore';
 
@@ -26,10 +26,21 @@ export function useSerialBackend(
   onNewSeriesRef.current = onNewSeries;
   const onHeaderResetRef = useRef(onHeaderReset);
   onHeaderResetRef.current = onHeaderReset;
+  // Gate: only accept samples while connected. Prevents stale in-flight events
+  // that arrive after a disconnect gap from creating ghost segments.
+  const acceptingSamplesRef = useRef(false);
 
   useEffect(() => {
     const subs = [
+      // Batch listener for real serial data (high-rate path).
+      listen<SampleBatch>('serial://sample-batch', (e) => {
+        if (!acceptingSamplesRef.current) return;
+        const isNew = ringStore.addSamples(e.payload.samples);
+        if (isNew) onNewSeriesRef.current();
+      }),
+      // Single-sample listener for the mock stream (low-rate path).
       listen<SampleEvent>('serial://sample', (e) => {
+        if (!acceptingSamplesRef.current) return;
         const { t_ms, values, labels } = e.payload;
         const isNew = ringStore.addSample(t_ms, values, labels);
         if (isNew) onNewSeriesRef.current();
@@ -40,7 +51,12 @@ export function useSerialBackend(
       listen<StatusEvent>('serial://status', (e) => {
         const s = e.payload.state;
         setStatus(s);
-        if (s === 'disconnected' || s === 'error') ringStore.addGap();
+        if (s === 'connected') {
+          acceptingSamplesRef.current = true;
+        } else {
+          acceptingSamplesRef.current = false;
+          ringStore.addGap();
+        }
       }),
       listen('serial://gap', () => {
         onHeaderResetRef.current();

--- a/src/store/RingStore.ts
+++ b/src/store/RingStore.ts
@@ -1,4 +1,4 @@
-const DEFAULT_CAPACITY = 100_000;
+const DEFAULT_CAPACITY = 500_000;
 
 export class RingStore {
   private _t: Float64Array;
@@ -15,6 +15,10 @@ export class RingStore {
 
   get length(): number { return this._size; }
   get seriesKeys(): readonly string[] { return this._keys; }
+  get lastTimestamp(): number {
+    if (this._size === 0) return Date.now();
+    return this._t[(this._head - 1 + this.capacity) % this.capacity];
+  }
 
   /** Add a sample. Returns true if a new series was created. */
   addSample(t_ms: number, values: number[], labels?: string[]): boolean {
@@ -34,13 +38,24 @@ export class RingStore {
       }
     }
 
+    // Build a key→value-index map once for O(1) lookup per series.
+    const keyIndex = new Map<string, number>(keys.map((k, i) => [k, i]));
     this._t[this._head] = t_ms;
     for (const [k, arr] of this._data) {
-      const idx = keys.indexOf(k);
-      arr[this._head] = idx >= 0 ? values[idx] : NaN;
+      const idx = keyIndex.get(k);
+      arr[this._head] = idx !== undefined ? values[idx] : NaN;
     }
 
     this._advance();
+    return newSeries;
+  }
+
+  /** Add a batch of samples. Returns true if any new series was created. */
+  addSamples(batch: { t_ms: number; values: number[]; labels?: string[] }[]): boolean {
+    let newSeries = false;
+    for (const s of batch) {
+      if (this.addSample(s.t_ms, s.values, s.labels)) newSeries = true;
+    }
     return newSeries;
   }
 
@@ -65,8 +80,33 @@ export class RingStore {
     }
   }
 
+  /**
+   * Like forEachSample but binary-searches for the first sample with t >= minT
+   * before iterating, skipping O(N) samples that are older than the visible window.
+   */
+  forEachSampleFrom(minT: number, cb: (t: number, ri: number) => boolean | void): void {
+    if (this._size === 0) return;
+    const startSlot = this._size < this.capacity ? 0 : this._head;
+    // Binary search for first logical index where t >= minT.
+    let lo = 0, hi = this._size - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (this._t[(startSlot + mid) % this.capacity] < minT) lo = mid + 1;
+      else hi = mid;
+    }
+    for (let i = lo; i < this._size; i++) {
+      const ri = (startSlot + i) % this.capacity;
+      if (cb(this._t[ri], ri) === false) break;
+    }
+  }
+
   getValue(key: string, ri: number): number {
     return this._data.get(key)?.[ri] ?? NaN;
+  }
+
+  /** Direct access to a series' backing array — avoids per-sample Map lookup in tight loops. */
+  getSeriesData(key: string): Float32Array | undefined {
+    return this._data.get(key);
   }
 
   clear(): void {

--- a/src/types/serial.ts
+++ b/src/types/serial.ts
@@ -10,6 +10,10 @@ export interface RawEvent {
   text: string;
 }
 
+export interface SampleBatch {
+  samples: SampleEvent[];
+}
+
 export interface StatusEvent {
   state: 'connected' | 'disconnected' | 'error';
   reason?: string;


### PR DESCRIPTION
### Changes:
- Batched IPC for high-rate data — Rust now collects all samples from a single read() call and emits one serial://sample-batch event  instead of one serial://sample per line. Cuts IPC crossings from O(samples/sec) to O(read-calls/sec), making audio-rate ADC streams (8–44 kHz) feasible.
- Raw console throttle — token-bucket limiter (100 events/sec) on serial://raw so the console pane doesn't flood and lag at high data rates.
- Canvas pixel-bucket downsampling — both Y-range calculation and line drawing now bin samples into pixel-wide buckets (min/max per bucket). Eliminates Y-axis jitter and makes rendering O(pixels) instead of O(samples) at high rates. endMs snaps to pixel-grid boundaries each frame to stabilise column assignments.
- forEachSampleFrom with binary search — ring buffer now skips old samples in O(log N) instead of scanning the whole buffer on every frame.
- Ring buffer capacity 100 k → 500 k samples; getSeriesData() direct array accessor added for tight render loops; addSamples() batch ingestion method added.
- Accepting-samples gate — frontend only ingests events while connected, preventing in-flight events after disconnect from creating ghost plot segments.
- Parser extracted to parser.rs with a full unit-test suite in tests.rs; lib.rs shrinks by ~120 lines.
- Console scroll fix — replaced sentinel <div ref> + scrollIntoView with direct scrollTop assignment; auto-scroll now only disables when the user actually scrolls up, not on programmatic scroll events.
- Mock stream available in release builds (was debug-only).
- Version bump to 0.3.0.

### Test plan

- Connect a device sending comma-separated values at normal baud rates (9600–115200) — chart renders, console scrolls, disconnect gap  appears correctly
- Connect a device sending data at audio rate (≥8 kHz) — chart remains smooth, CPU stays reasonable, console throttles without hanging
- Scrub/zoom while live data is arriving at high rate — no Y-axis jitter, no missed redraws
- Disconnect mid-stream — no ghost segments after reconnect
- Send a new # header mid-stream — ring buffer clears, new series names appear
- Console manual scroll-up freezes auto-scroll; reaching bottom re-enables it
- Mock stream works in both dev and release builds
- cargo clippy and tsc --noEmit pass clean